### PR TITLE
Correct the path for when wp-config.php is in a parent directory.

### DIFF
--- a/lib/Runner.php
+++ b/lib/Runner.php
@@ -33,7 +33,7 @@ class Runner {
 
 		$config_path = realpath( $wp_path . '/wp-config.php' );
 		if ( ! file_exists( $config_path ) ) {
-			$config_path = realpath( $wp_path . '/../wp-config.php ');
+			$config_path = realpath( $wp_path . '/../wp-config.php' );
 			if ( ! file_exists( $config_path ) ) {
 				throw new Exception( sprintf( 'Could not find config file at %s', realpath( $wp_path ) . '/wp-config.php or next level up.' ) );
 			}


### PR DESCRIPTION
It seems that when #13 was merged, a stray space entered the file path, which at least on my system causes `realpath()` to fail.