### PR TITLE
Enable disabling Cavalcade startup with presence of disable file

### DIFF
--- a/systemd.service
+++ b/systemd.service
@@ -8,7 +8,9 @@ TimeoutStopSec=600
 Restart=always
 WorkingDirectory=/srv/www/webroot
 User=www-data
-ExecStart=/etc/cavalcade/bin/cavalcade
+SuccessExitStatus=3
+RestartPreventExitStatus=3
+ExecStart=/usr/bin/env bash -c '(test ! -f /etc/cavalcade.disabled || exit 3) && /etc/cavalcade/bin/cavalcade'
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd.service
+++ b/systemd.service
@@ -8,7 +8,7 @@ TimeoutStopSec=600
 Restart=always
 WorkingDirectory=/srv/www/webroot
 User=www-data
-SuccessExitStatus=3
+SuccessExitStatus=0 3
 RestartPreventExitStatus=3
 ExecStart=/usr/bin/env bash -c '(test ! -f /etc/cavalcade.disabled || exit 3) && /etc/cavalcade/bin/cavalcade'
 

--- a/upstart.conf
+++ b/upstart.conf
@@ -5,9 +5,10 @@ start on startup
 stop on shutdown
 respawn
 kill timeout 600
+normal exit 0 3
 
 chdir /srv/www/webroot
 setuid www-data
 script
-  exec /etc/cavalcade/bin/cavalcade
+  exec /usr/bin/env bash -c "(test ! -f /etc/cavalcade.disabled || exit 3) && /etc/cavalcade/bin/cavalcade"
 end script


### PR DESCRIPTION
This PR updates the upstart/systemd configs to check for the presence of `/etc/cavalcade.disabled`. If it exists, it exits gracefully and won't attempt to respawn the service. This is useful if explicit web and worker servers are desired, and the same underlying server image wants to be used. The web server can be differentiated on server creation by creating a `/etc/cavalcade.disabled` file via `user_data`.