### PR TITLE
Drain the Worker pipes during the process instead of only at the end.

### DIFF
--- a/lib/Runner.php
+++ b/lib/Runner.php
@@ -224,6 +224,7 @@ class Runner {
 		// Clean up all of the finished workers
 		foreach ( $pipes as $id => $stream ) {
 			$worker = $this->workers[ $id ];
+			$worker->drain_pipes();
 			if ( ! $worker->is_done() ) {
 				// Process hasn't exited yet, keep rocking on
 				continue;

--- a/lib/Runner.php
+++ b/lib/Runner.php
@@ -174,6 +174,10 @@ class Runner {
 			throw new Exception();
 		}
 
+		// Disable blocking to allow partial stream reads before EOF.
+		stream_set_blocking( $pipes[1], false );
+		stream_set_blocking( $pipes[2], false );
+
 		$this->workers[] = new Worker( $process, $pipes, $job );
 		printf( '[%d] Started worker' . PHP_EOL, $job->id );
 	}

--- a/lib/Runner.php
+++ b/lib/Runner.php
@@ -201,28 +201,39 @@ class Runner {
 			return true;
 		}
 
-		$pipes = array();
+		$pipes_stdout = $pipes_stderr = array();
 		foreach ( $this->workers as $id => $worker ) {
-			$pipes[ $id ] = $worker->pipes[1];
+			$pipes_stdout[ $id ] = $worker->pipes[1];
+			$pipes_stderr[ $id ] = $worker->pipes[2];
 		}
 
 		// Grab all the pipes ready to close
 		$a = $b = null; // Dummy vars for reference passing
-		$changed = stream_select( $pipes, $a, $b, 0 );
-		if ( $changed === false ) {
+
+		$changed_stdout = stream_select( $pipes_stdout, $a, $b, 0 );
+		if ( $changed_stdout === false ) {
 			// ERROR!
 			return false;
 		}
 
-		if ( $changed === 0 ) {
+		$changed_stderr = stream_select( $pipes_stderr, $a, $b, 0 );
+		if ( $changed_stderr === false ) {
+			// ERROR!
+			return false;
+		}
+
+		if ( $changed_stdout === 0 && $changed_stderr === 0 ) {
 			// No change, try again
 			return true;
 		}
 
+		// List of Workers with a changed state
+		$changed_workers = array_merge( array_keys( $pipes_stdout ), array_keys( $pipes_stderr ) );
+
 		$logger = new Logger( $this->db, $this->table_prefix );
 
 		// Clean up all of the finished workers
-		foreach ( $pipes as $id => $stream ) {
+		foreach ( $changed_workers as $id ) {
 			$worker = $this->workers[ $id ];
 			$worker->drain_pipes();
 			if ( ! $worker->is_done() ) {

--- a/lib/Worker.php
+++ b/lib/Worker.php
@@ -38,11 +38,12 @@ class Worker {
 	 * Draining the pipes is needed to avoid workers hanging when they hit the system pipe buffer limits.
 	 */
 	public function drain_pipes() {
-		while ( ! feof( $this->pipes[1] ) ) {
-			$this->output .= fread( $this->pipes[1], 1024 );
+		while ( $data = fread( $this->pipes[1], 1024 ) ) {
+			$this->output .= $data;
 		}
-		while ( ! feof( $this->pipes[2] ) ) {
-			$this->error_output .= fread( $this->pipes[2], 1024 );
+
+		while ( $data = fread( $this->pipes[2], 1024 ) ) {
+			$this->error_output .= $data;
 		}
 	}
 


### PR DESCRIPTION
Drain the Worker pipes during the process instead of only at the end.

This prevents jobs hanging when the system pipe buffer fills up.

Props rmccue, Fixes https://github.com/humanmade/Cavalcade/issues/37.