### PR TITLE
Specify an order in Runner\get_next_job() to always process the oldest job (by date) first.

### DIFF
--- a/lib/Runner.php
+++ b/lib/Runner.php
@@ -137,6 +137,8 @@ class Runner {
 	protected function get_next_job() {
 		$query = "SELECT * FROM {$this->table_prefix}cavalcade_jobs";
 		$query .= ' WHERE nextrun < NOW() AND status = "waiting"';
+		$query .= ' ORDER BY nextrun ASC';
+		$query .= ' LIMIT 1';
 
 		$statement = $this->db->prepare( $query );
 		$statement->execute();


### PR DESCRIPTION
Specify an order in Runner\get_next_job() to always process the oldest job (by date) first.

Fixes an issue where when a backlog exists jobs are processed by id order rather than date order.

Fixes https://github.com/humanmade/Cavalcade/issues/38