### PR TITLE
Fix notice if there are no hooks added.

### DIFF
--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -36,6 +36,9 @@ class Hooks {
 	 * @return mixed Filtered value after running through callbacks.
 	 */
 	public function run( $hook, $value = null, ...$args ) {
+		if ( ! isset( $this->callbacks[ $hook ] ) ) {
+			return $value;
+		}
 		foreach ( $this->callbacks[ $hook ] as $priority => $callbacks ) {
 			foreach ( $callbacks as $callback ) {
 				$value = $callback( $value, ...$args );


### PR DESCRIPTION
Causes things like
```
Warning: Invalid argument supplied for foreach() in /Users/joe/php/Cavalcade-Runner/lib/Hooks.php on line 39
PHP Notice:  Undefined index: Runner.connect_to_db.connected in /Users/joe/php/Cavalcade-Runner/lib/Hooks.php on line 39