### PR TITLE
Fix typo in variable names for completed and failed hooks.

### DIFF
--- a/lib/Runner.php
+++ b/lib/Runner.php
@@ -350,7 +350,7 @@ class Runner {
 				 * @param Worker $worker Worker that ran the job.
 				 * @param Job $job Job that failed.
 				 */
-				$this->hooks->run( 'Runner.check_workers.job_failed', $worker, $job );
+				$this->hooks->run( 'Runner.check_workers.job_failed', $worker, $worker->job );
 			} else {
 				$worker->job->mark_completed();
 				$logger->log_job_completed( $worker->job );
@@ -360,7 +360,7 @@ class Runner {
 				 * @param Worker $worker Worker that ran the job.
 				 * @param Job $job Job that completed.
 				 */
-				$this->hooks->run( 'Runner.check_workers.job_completed', $worker, $job );
+				$this->hooks->run( 'Runner.check_workers.job_completed', $worker, $worker->job );
 			}
 
 			unset( $this->workers[ $id ] );


### PR DESCRIPTION
Introduced in b913a1c, my bad