### PR TITLE
Fix fatal when workers have output.

### DIFF
--- a/lib/Runner.php
+++ b/lib/Runner.php
@@ -347,7 +347,7 @@ class Runner {
 		}
 
 		// List of Workers with a changed state
-		$changed_workers = array_merge( array_keys( $pipes_stdout ), array_keys( $pipes_stderr ) );
+		$changed_workers = array_unique( array_merge( array_keys( $pipes_stdout ), array_keys( $pipes_stderr ) ) );
 
 		/**
 		 * Filter for using a custom Logger implementation, instead of the


### PR DESCRIPTION
Introduced in https://github.com/humanmade/Cavalcade-Runner/commit/1b9815653ef8fb62715ded7f56e1f8ce1465949c#diff-18c4ff63288c2ab849b732b2f72a1112R231. https://github.com/humanmade/Cavalcade-Runner/commit/1b9815653ef8fb62715ded7f56e1f8ce1465949c#diff-18c4ff63288c2ab849b732b2f72a1112R231 specifically made Worker IDs duplicated in `$changed_workers`. This meant that a given worker ID can be iterated over more than once (because it's in the $changed_workers array more than once). Because we (sometimes) `unset` the worrker in the `foreach` loop, then the second time a worker ID is iterated, we get a fatal error due to the worker no longer existing in the `$this->workers` array.

The fatal is:

```
PHP Fatal error:  Uncaught Error: Call to a member function drain_pipes() on null in /etc/cavalcade/lib/Runner.php:366
Stack trace:
  thrown in /etc/cavalcade/lib/Runner.php on line 366
```

This match will basically make it so a worker ID can not appear more than once in the `$changed_workers` loop.