### PR TITLE
Add composer.json with system extension requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,7 @@
 {
 	"name": "humanmade/cavalcade-runner",
-	"description": "PHP-Runner for cavalcade, a better wp-cron.",
+	"description": "Daemon for Cavalcade, a scalable WordPress jobs system.",
 	"homepage": "https://github.com/humanmade/Cavalcade-Runner",
-	"type": "library",
 	"license": "GPL-2.0+",
 	"authors": [
 		{
@@ -20,8 +19,5 @@
 	},
 	"bin": [
 		"bin/cavalcade"
-	],
-	"suggest": {
-        "humanmade/cavalcade": "To use Cavalcade-Runner you need Cavalcade mu-plugin for WordPress too"
-    }
+	]
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+	"name": "humanmade/cavalcade-runner",
+	"description": "PHP-Runner for cavalcade, a better wp-cron.",
+	"homepage": "https://github.com/humanmade/Cavalcade-Runner",
+	"type": "library",
+	"license": "GPL-2.0+",
+	"authors": [
+		{
+			"name": "Human Made",
+			"homepage": "https://hmn.md/"
+		}
+	],
+	"require-dev": {
+		"humanmade/coding-standards": "dev-master"
+	},
+	"bin": [
+		"bin/cavalcade"
+	]
+}

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,18 @@
 			"homepage": "https://hmn.md/"
 		}
 	],
+	"require": {
+		"php": ">=5.6",
+		"ext-pcntl": "*",
+		"ext-pdo_mysql": "*"
+	},
 	"require-dev": {
 		"humanmade/coding-standards": "dev-master"
 	},
 	"bin": [
 		"bin/cavalcade"
-	]
+	],
+	"suggest": {
+        "humanmade/cavalcade": "To use Cavalcade-Runner you need Cavalcade mu-plugin for WordPress too"
+    }
 }


### PR DESCRIPTION
This would allow me to install this project inside my projects with `composer` and setting the correct symlink to `vendor/bin`.

This way I can use it with `cd /path/to/wordpress && cavalcade` because I have `$PROJECT_DIR/vendor/bin` in my `$PATH`.