### PR TITLE
Add automatic phpcs check with Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore OSX garbage
+.DS_Store
+
+# Ignore composer installed libraries and lock
+vendor
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: php
+php:
+  - '7.1'
+install:
+  - composer install
+script:
+  - vendor/bin/phpcs --standard=phpcs.ruleset.xml .

--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
+<table width="100%">
+	<tr>
+		<td align="left" width="70">
+			<strong>Cavalcade</strong><br />
+			Daemon for Cavalcade, a scalable WordPress jobs system.
+		</td>
+		<td align="right" width="20%">
+			<a href="https://travis-ci.org/humanmade/Cavalcade-Runner">
+				<img src="https://travis-ci.org/humanmade/Cavalcade-Runner.svg?branch=master" alt="Build status">
+			</a>
+		</td>
+	</tr>
+	<tr>
+		<td>
+			A <strong><a href="https://hmn.md/">Human Made</a></strong> project. Maintained by @rmccue.
+		</td>
+		<td align="center">
+			<img src="https://hmn.md/content/themes/hmnmd/assets/images/hm-logo.svg" width="100" />
+		</td>
+	</tr>
+</table>
 # Cavalcade Runner
 
 This is the runner for Cavalcade. Head over to the [Cavalcade repo](https://github.com/humanmade/Cavalcade) to learn

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset>
+	<!-- Add files to check. -->
+	<file>lib/</file>
+	<file>bin/</file>
+	<file>bootstrap.php</file>
+
+	<!-- Use HM Coding Standards -->
+	<rule ref="vendor/humanmade/coding-standards">
+		<!-- Disable dumb DB complaints -->
+		<exclude name="WordPress.WP.PreparedSQL" />
+		<exclude name="WordPress.DB.RestrictedClasses.mysql" />
+		<exclude name="WordPress.DB.RestrictedFunctions.mysql" />
+	</rule>
+</ruleset>


### PR DESCRIPTION
In order to automatically check Humanmade coding standards we should enable Travis CI for this repo.

I copied the basic settings for this from https://github.com/humanmade/Cavalcade.

I also added the readme header you usually use including the Travis CI badge.