### PR TITLE
Add accessor for $wp_path

### DIFF
--- a/inc/class-runner.php
+++ b/inc/class-runner.php
@@ -166,7 +166,7 @@ class Runner {
 
 		throw new SignalInterrupt( 'Terminated by signal', $signal );
 	}
-	
+
 	public function get_wp_path() {
 		return $this->wp_path;
 	}

--- a/inc/class-runner.php
+++ b/inc/class-runner.php
@@ -166,6 +166,10 @@ class Runner {
 
 		throw new SignalInterrupt( 'Terminated by signal', $signal );
 	}
+	
+	public function get_wp_path() {
+		return $this->wp_path;
+	}
 
 	protected function connect_to_db() {
 		$charset = defined( 'DB_CHARSET' ) ? DB_CHARSET : 'utf8';


### PR DESCRIPTION
Currently it's protected but could be useful in some cases where files other than `wp-settings.php` are loaded early.