### PR TITLE
Improved support for local MySQL time

### DIFF
--- a/inc/class-runner.php
+++ b/inc/class-runner.php
@@ -201,6 +201,7 @@ class Runner {
 		 */
 		$options = $this->hooks->run( 'Runner.connect_to_db.options', [], $dsn, DB_USER, DB_PASSWORD );
 		$this->db = new PDO( $dsn, DB_USER, DB_PASSWORD, $options );
+		$this->db->exec( 'SET time_zone = "+00:00"' );
 
 		// Set it up just how we like it
 		$this->db->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );

--- a/inc/class-runner.php
+++ b/inc/class-runner.php
@@ -201,11 +201,11 @@ class Runner {
 		 */
 		$options = $this->hooks->run( 'Runner.connect_to_db.options', [], $dsn, DB_USER, DB_PASSWORD );
 		$this->db = new PDO( $dsn, DB_USER, DB_PASSWORD, $options );
-		$this->db->exec( 'SET time_zone = "+00:00"' );
 
 		// Set it up just how we like it
 		$this->db->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
 		$this->db->setAttribute( PDO::ATTR_EMULATE_PREPARES, false );
+		$this->db->exec( 'SET time_zone = "+00:00"' );
 
 		/**
 		 * Action after connecting to the database.


### PR DESCRIPTION
Fix to ensure that MySQL NOW() uses the same timezone as wp_cavalcade_jobs.nextrun

Fixes https://github.com/humanmade/Cavalcade/issues/55