### PR TITLE
Add 'Runner.run.loop_start' hook

### DIFF
--- a/inc/class-runner.php
+++ b/inc/class-runner.php
@@ -105,6 +105,16 @@ class Runner {
 			// Check for any signals we've received
 			pcntl_signal_dispatch();
 
+			/**
+			* Action at the start of every loop iteration.
+			*
+			* PDO connection used to query against current state of Cavalcade
+			* jobs.
+			*
+			* @param PDO $db PDO database connection.
+			*/
+			$this->hooks->run( 'Runner.run.loop_start', $this->db );
+
 			// Check the running workers
 			$this->check_workers();
 

--- a/inc/class-runner.php
+++ b/inc/class-runner.php
@@ -105,13 +105,13 @@ class Runner {
 			pcntl_signal_dispatch();
 
 			/**
-			* Action at the start of every loop iteration.
-			*
-			* PDO connection used to query against current state of Cavalcade
-			* jobs.
-			*
-			* @param PDO $db PDO database connection.
-			*/
+			 * Action at the start of every loop iteration.
+			 *
+			 * PDO connection used to query against current state of Cavalcade
+			 * jobs.
+			 *
+			 * @param PDO $db PDO database connection.
+			 */
 			$this->hooks->run( 'Runner.run.loop_start', $this->db );
 
 			// Check the running workers

--- a/inc/class-runner.php
+++ b/inc/class-runner.php
@@ -107,12 +107,9 @@ class Runner {
 			/**
 			 * Action at the start of every loop iteration.
 			 *
-			 * PDO connection used to query against current state of Cavalcade
-			 * jobs.
-			 *
-			 * @param PDO $db PDO database connection.
+			 * @param Runner $this Instance of the Cavalcade Runner
 			 */
-			$this->hooks->run( 'Runner.run.loop_start', $this->db );
+			$this->hooks->run( 'Runner.run.loop_start', $this );
 
 			// Check the running workers
 			$this->check_workers();


### PR DESCRIPTION
Runs at the beginning of every loop iteration. Can be used to check the current status of Cavalcade, such as the number of jobs in the backlog as it passes the current database connection.