### PR TITLE
Handle SIGQUIT signals

### DIFF
--- a/inc/class-runner.php
+++ b/inc/class-runner.php
@@ -94,6 +94,7 @@ class Runner {
 		// Handle SIGTERM calls
 		pcntl_signal( SIGTERM, [ $this, 'terminate' ] );
 		pcntl_signal( SIGINT, [ $this, 'terminate' ] );
+		pcntl_signal( SIGQUIT, [ $this, 'terminate' ] );
 
 		/**
 		 * Action before starting to run.


### PR DESCRIPTION
This allows us to respond to SIGQUIT, which we're encountering in the ECS infrastructure.