### PR TITLE
Enable access to Worker::output / error_output / status from hooks

### DIFF
--- a/inc/class-worker.php
+++ b/inc/class-worker.php
@@ -10,9 +10,9 @@ class Worker {
 	public $pipes = [];
 	public $job;
 
-	protected $output = '';
-	protected $error_output = '';
-	protected $status = null;
+	public $output = '';
+	public $error_output = '';
+	public $status = null;
 
 	public function __construct( $process, $pipes, Job $job ) {
 		$this->process = $process;


### PR DESCRIPTION
By making these properties public, it allows the `Runner.check_workers.job_failed` and `Runner.check_workers.job_completed` actions to access the STDOUT/STDERR streams from the worker.

Fixes https://github.com/humanmade/Cavalcade/issues/24