### PR TITLE
Pass $logger to Runner.check_workers.job_failed & Runner.check_workers.job_completed

### DIFF
--- a/inc/class-runner.php
+++ b/inc/class-runner.php
@@ -392,8 +392,9 @@ class Runner {
 				 *
 				 * @param Worker $worker Worker that ran the job.
 				 * @param Job $job Job that failed.
+				 * @param Logger $logger Logger for the job.
 				 */
-				$this->hooks->run( 'Runner.check_workers.job_failed', $worker, $worker->job );
+				$this->hooks->run( 'Runner.check_workers.job_failed', $worker, $worker->job, $logger );
 			} else {
 				$worker->job->mark_completed();
 				$logger->log_job_completed( $worker->job );
@@ -403,8 +404,9 @@ class Runner {
 				 *
 				 * @param Worker $worker Worker that ran the job.
 				 * @param Job $job Job that completed.
+				 * @param Logger $logger Logger for the job.
 				 */
-				$this->hooks->run( 'Runner.check_workers.job_completed', $worker, $worker->job );
+				$this->hooks->run( 'Runner.check_workers.job_completed', $worker, $worker->job, $logger );
 			}
 
 			unset( $this->workers[ $id ] );


### PR DESCRIPTION
By passing $logger to the check_workers filters, a custom logger can be used to record extra log details.

In this case, I'm using a custom logger on WordPress.org to record more details for storage in the database that would normally only be stored in the on-disk logs.