### PR TITLE
Statically cache whether wp_blogs exists

### DIFF
--- a/inc/class-job.php
+++ b/inc/class-job.php
@@ -35,7 +35,7 @@ class Job {
 
 	public function get_site_url() {
 
-		if ( ! self::blogs_table_exists() ) {
+		if ( ! $this->blogs_table_exists() ) {
 			return false;
 		}
 

--- a/inc/class-job.php
+++ b/inc/class-job.php
@@ -26,7 +26,7 @@ class Job {
 	/**
 	 * @var null|bool
 	 */
-	static protected $blogs_table_exists;
+	protected static $blogs_table_exists;
 
 	public function __construct( $db, $table_prefix ) {
 		$this->db = $db;

--- a/inc/class-job.php
+++ b/inc/class-job.php
@@ -23,17 +23,19 @@ class Job {
 	protected $db;
 	protected $table_prefix;
 
+	/**
+	 * @var null|bool
+	 */
+	static protected $blogs_table_exists;
+
 	public function __construct( $db, $table_prefix ) {
 		$this->db = $db;
 		$this->table_prefix = $table_prefix;
 	}
 
 	public function get_site_url() {
-		$query = "SHOW TABLES LIKE '{$this->table_prefix}blogs'";
-		$statement = $this->db->prepare( $query );
-		$statement->execute();
 
-		if ( 0 === $statement->rowCount() ) {
+		if ( ! self::blogs_table_exists() ) {
 			return false;
 		}
 
@@ -47,6 +49,20 @@ class Job {
 		$data = $statement->fetch( PDO::FETCH_ASSOC );
 		$url = $data['domain'] . $data['path'];
 		return $url;
+	}
+
+	protected function blogs_table_exists() {
+		if ( static::$blogs_table_exists !== null ) {
+			return static::$blogs_table_exists;
+		}
+
+		$query = "SHOW TABLES LIKE '{$this->table_prefix}blogs'";
+		$statement = $this->db->prepare( $query );
+		$statement->execute();
+
+		static::$blogs_table_exists = $statement->rowCount() > 0;
+
+		return static::$blogs_table_exists;
 	}
 
 	/**


### PR DESCRIPTION
Doing `SHOW TABLES LIKE` is very slow in Mysql 8+ when there are many tables (say, more than 50k). There's not really much reason to run this every time. Worst case Cavalcade needs to be restarted after installing the database (which might already be the case anyway TBH)
