### PR TITLE
Pass context to the logger class override hook

### DIFF
--- a/inc/class-runner.php
+++ b/inc/class-runner.php
@@ -372,7 +372,9 @@ class Runner {
 		 */
 		$logger = $this->hooks->run(
 			'Runner.check_workers.logger',
-			new Logger( $this->db, $this->table_prefix )
+			new Logger( $this->db, $this->table_prefix ),
+			$this->db,
+			$this->table_prefix
 		);
 
 		// Clean up all of the finished workers


### PR DESCRIPTION
When extending the Logger class, information about the Database connection is likely to be required by the Logger.

Prior to #72 7af82ca60bae6b4f589370a516c3c378e95a1cc9 the following code worked:
```php
$runner->hooks->register( 'Runner.check_workers.logger', function( $logger ) {
	return new MyLogger( $logger->db, $logger->table_prefix );
} );
```

Now code similar to this is required:
```php
$runner->hooks->register( 'Runner.connect_to_db.connected', function( $db ) {
	$GLOBALS['_cavalcade_db'] = $db;
} );
$runner->hooks->register( 'Runner.bootstrap.table_prefix', function( $table_prefix ) {
	$GLOBALS['_cavalcade_table_prefix'] = $table_prefix;

	return $table_prefix;
} );
$runner->hooks->register( 'Runner.check_workers.logger', function( $logger ) {
	return new MyLogger(
		$GLOBALS['_cavalcade_db'],
		$GLOBALS['_cavalcade_table_prefix']
	);
} );
```

Alternatively, these could be made public, but just passing it as an extra arg is probably enough.. 