### PR TITLE
Pass the $worker object to the Logger instance

### DIFF
--- a/inc/class-logger.php
+++ b/inc/class-logger.php
@@ -11,11 +11,11 @@ class Logger {
 		$this->table_prefix = $table_prefix;
 	}
 
-	public function log_job_completed( Job $job, $message = '' ) {
+	public function log_job_completed( Job $job, $message, Worker $worker ) {
 		$this->log_run( $job->id, 'completed', $message );
 	}
 
-	public function log_job_failed( Job $job, $message = '' ) {
+	public function log_job_failed( Job $job, $message, Worker $worker ) {
 		$this->log_run( $job->id, 'failed', $message );
 	}
 

--- a/inc/class-runner.php
+++ b/inc/class-runner.php
@@ -386,7 +386,7 @@ class Runner {
 
 			if ( ! $worker->shutdown() ) {
 				$worker->job->mark_failed();
-				$logger->log_job_failed( $worker->job, 'Failed to shutdown worker.' );
+				$logger->log_job_failed( $worker->job, 'Failed to shutdown worker.', $worker );
 
 				/**
 				 * Action after a job has failed.
@@ -398,7 +398,7 @@ class Runner {
 				$this->hooks->run( 'Runner.check_workers.job_failed', $worker, $worker->job, $logger );
 			} else {
 				$worker->job->mark_completed();
-				$logger->log_job_completed( $worker->job );
+				$logger->log_job_completed( $worker->job, '', $worker );
 
 				/**
 				 * Action after a job has failed.


### PR DESCRIPTION
The Logger instance does not have access to the STDOUT or STDERR pipes of the worker by default.

This is achievable using something like this in older PHP versions, but this causes PHP Deprecated warnings in newer PHPs.
```php
$runner->hooks->register( 'Runner.run_job.started', function( Worker $worker, Job $job ) {
	$job->_worker = $worker;
} );
```

It would also be possible for the logger to not update it's datastore on `log_job_failed()`/`log_job_completed()` and instead to wait for the following hook `Runner.check_workers.job_completed` to be fired to then update it's data:
```php
$runner->hooks->register( 'Runner.check_workers.job_completed', function( $worker, $job, $logger ) {
	$logger->completed( $job, $worker );
} );

class MyLogger extends Logger {
	public $message = '';

	public function log_job_completed( Job $job, $message = '' ) {
		$this->message = $message;
	}

	public function completed( Job $job, Worker $worker ) {
		$data = json_encode( array_filter(array(
			'message' => $this->message,
			'stdout'  => $worker->output,
			'stderr'  => $worker->error_output
		) ) );

		$this->log_run( $job->id, 'completed', $data );
	}
....
```

Be nice to just have everything accessible though.