### PR TITLE
Use indexed query in `blogs_table_exists()`.

### DIFF
--- a/inc/class-job.php
+++ b/inc/class-job.php
@@ -56,11 +56,16 @@ class Job {
 			return static::$blogs_table_exists;
 		}
 
-		$query = "SHOW TABLES LIKE '{$this->table_prefix}blogs'";
-		$statement = $this->db->prepare( $query );
-		$statement->execute();
+		$query  = "
+			SELECT 1
+			FROM   INFORMATION_SCHEMA.TABLES
+			WHERE  TABLE_SCHEMA = DATABASE()
+			  AND  TABLE_NAME   = :tbl
+		";
+		$statement   = $this->db->prepare( $query );
+		$statement->execute( [ ':tbl' => "{$this->table_prefix}blogs" ] );
 
-		static::$blogs_table_exists = $statement->rowCount() > 0;
+		static::$blogs_table_exists = (bool) $statement->fetchColumn();
 
 		return static::$blogs_table_exists;
 	}


### PR DESCRIPTION
In #77, static caching was added for the `wp_blogs` existence query. Thanks very much for that change - it's a problem we had to hotfix around in the past.

The current PR suggests a further streamlining. `SHOW TABLES LIKE 'wp_blogs'` is slow because it results in an unindexed query against `INFORMATION_SCHEMA`. If we add a `TABLE_SCHEMA` clause, we can leverage the indexes, and the query is dramatically faster. (Alternatively, you could use `DESCRIBE wp_blogs`, which looks only at tablespace.) 